### PR TITLE
Add pytest-based tests for EKM

### DIFF
--- a/eigen_koan_matrix.py
+++ b/eigen_koan_matrix.py
@@ -1,17 +1,27 @@
 # eigen_koan_matrix.py - Core implementation of Eigen-Koan Matrices
 # ---------------------------------------------------------
 
-import numpy as np
+try:
+    import numpy as np
+except Exception:  # pragma: no cover - optional
+    from types import SimpleNamespace
+    from typing import Any
+    np = SimpleNamespace(ndarray=Any)  # type: ignore
 import random
 import json
 import datetime
 import uuid
 from typing import List, Dict, Tuple, Optional, Union, Callable
 from dataclasses import dataclass
-from rich.console import Console
-from rich.table import Table
+try:
+    from rich.console import Console
+    from rich.table import Table
+except Exception:  # pragma: no cover - optional
+    Console = None  # type: ignore
+    class Table:  # type: ignore
+        pass
 
-console = Console()
+console = Console() if Console else None
 
 @dataclass
 class DiagonalAffect:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -vv

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -1,0 +1,43 @@
+import builtins
+from eigen_koan_matrix import EigenKoanMatrix, DiagonalAffect
+from recursive_ekm import RecursiveEKM
+
+
+def make_matrix(tokens_main, tokens_anti):
+    main = DiagonalAffect("Main", tokens_main, "", 0.0, 0.0)
+    anti = DiagonalAffect("Anti", tokens_anti, "", 0.0, 0.0)
+    size = len(tokens_main)
+    cells = [["{NULL}" for _ in range(size)] for _ in range(size)]
+    for i in range(size):
+        cells[i][i] = tokens_main[i]
+        cells[i][size-1-i] = tokens_anti[i]
+    tasks = [f"T{i+1}" for i in range(size)]
+    constraints = [f"C{i+1}" for i in range(size)]
+    return EigenKoanMatrix(size=size, task_rows=tasks, constraint_cols=constraints,
+                           main_diagonal=main, anti_diagonal=anti, cells=cells)
+
+def test_generate_micro_prompt_basic():
+    ekm = make_matrix(["m1","m2"], ["a1","a2"])
+    prompt = ekm.generate_micro_prompt([0,1], include_metacommentary=False)
+    assert prompt == "T1 C1 using m1. T2 C2 using m2. "
+
+    prompt_meta = ekm.generate_micro_prompt([0,1], include_metacommentary=True)
+    assert "After completing this task" in prompt_meta
+
+def test_recursive_ekm_traversal():
+    root = make_matrix(["rm1","rm2"], ["ra1","ra2"])
+    sub = make_matrix(["sm1","sm2"], ["sa1","sa2"])
+    rec = RecursiveEKM(root_matrix=root, name="R")
+    rec.add_sub_matrix(0,0, sub)
+    sub_path = {(0,0): [1,0]}
+
+    expected_root = root.generate_micro_prompt([0,1], False)
+    expected_sub = sub.generate_micro_prompt([1,0], False)
+    prompt = rec.generate_multi_level_prompt([0,1], sub_paths=sub_path, include_metacommentary=False)
+    assert prompt == expected_root + "\n" + expected_sub
+
+    def dummy(p):
+        return "resp:" + p
+    result = rec.traverse(dummy, [0,1], sub_paths=sub_path, include_metacommentary=False)
+    assert result["prompt"] == prompt
+    assert result["response"] == "resp:" + prompt


### PR DESCRIPTION
## Summary
- allow importing modules without optional dependencies
- implement a minimal RecursiveEKM class
- provide helper to create example recursive matrix
- add pytest-based tests for EigenKoanMatrix and RecursiveEKM

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*