### PR TITLE
Add deterministic traversal options

### DIFF
--- a/eigen_koan_matrix.py
+++ b/eigen_koan_matrix.py
@@ -224,10 +224,13 @@ class EigenKoanMatrix:
         console.print(f"[italic]Main Diagonal Affect:[/italic] [blue]{self.main_diagonal.name}[/blue]")
         console.print(f"[italic]Anti-Diagonal Affect:[/italic] [red]{self.anti_diagonal.name}[/red]")
     
-    def traverse(self, 
-                model_fn: Callable[[str], str], 
-                path: Optional[List[int]] = None,
-                include_metacommentary: bool = True) -> Dict:
+    def traverse(
+        self,
+        model_fn: Callable[[str], str],
+        path: Optional[List[int]] = None,
+        include_metacommentary: bool = True,
+        seed: Optional[int] = None,
+    ) -> Dict:
         """
         Traverse the matrix using the given path and query a model with the resulting prompt.
         
@@ -235,13 +238,15 @@ class EigenKoanMatrix:
             model_fn: Function that takes a prompt string and returns model output
             path: Optional specific path to traverse. If None, generates a random valid path.
             include_metacommentary: Whether to ask model for reflection on its process
+            seed: Optional seed for deterministic path generation
             
         Returns:
             Dict containing the path, prompt, model response and metadata
         """
         # Generate random path if none provided
         if path is None:
-            path = [random.randint(0, self.size-1) for _ in range(self.size)]
+            rng = random.Random(seed) if seed is not None else random
+            path = [rng.randint(0, self.size - 1) for _ in range(self.size)]
             
         # Create path signature for caching
         path_sig = '_'.join(map(str, path))
@@ -287,10 +292,13 @@ class EigenKoanMatrix:
         
         return result
         
-    def multi_traverse(self,
-                      model_fn: Callable[[str], str],
-                      num_paths: int = 10,
-                      include_metacommentary: bool = True) -> List[Dict]:
+    def multi_traverse(
+        self,
+        model_fn: Callable[[str], str],
+        num_paths: int = 10,
+        include_metacommentary: bool = True,
+        seed: Optional[int] = None,
+    ) -> List[Dict]:
         """
         Traverse the matrix multiple times with different random paths.
         
@@ -298,14 +306,17 @@ class EigenKoanMatrix:
             model_fn: Function that takes a prompt string and returns model output
             num_paths: Number of random paths to generate
             include_metacommentary: Whether to ask model for reflection
+            seed: Optional seed for deterministic path generation
             
         Returns:
             List of result dictionaries from each traversal
         """
         results = []
-        
+        rng = random.Random(seed) if seed is not None else random
+
         for _ in range(num_paths):
-            result = self.traverse(model_fn, path=None, include_metacommentary=include_metacommentary)
+            path = [rng.randint(0, self.size - 1) for _ in range(self.size)]
+            result = self.traverse(model_fn, path=path, include_metacommentary=include_metacommentary)
             results.append(result)
             
         return results

--- a/recursive_ekm.py
+++ b/recursive_ekm.py
@@ -47,18 +47,18 @@ class RecursiveEKM:
         primary_path: List[int],
         sub_paths: Optional[Dict[Tuple[int, int], List[int]]] = None,
         include_metacommentary: bool = True,
+        seed: Optional[int] = None,
     ) -> str:
         """Generate a prompt that traverses the root and any nested matrices."""
-        prompt = self.root_matrix.generate_micro_prompt(
-            primary_path, include_metacommentary
-        )
+        rng = random.Random(seed) if seed is not None else random
+        prompt = self.root_matrix.generate_micro_prompt(primary_path, include_metacommentary)
 
         for (row, col), matrix in self.sub_matrices.items():
             path = None
             if sub_paths and (row, col) in sub_paths:
                 path = sub_paths[(row, col)]
             else:
-                path = [random.randint(0, matrix.size - 1) for _ in range(matrix.size)]
+                path = [rng.randint(0, matrix.size - 1) for _ in range(matrix.size)]
 
             sub_prompt = matrix.generate_micro_prompt(path, include_metacommentary)
             prompt += (
@@ -73,16 +73,18 @@ class RecursiveEKM:
         primary_path: Optional[List[int]] = None,
         sub_paths: Optional[Dict[Tuple[int, int], List[int]]] = None,
         include_metacommentary: bool = True,
+        seed: Optional[int] = None,
     ) -> Dict:
         """Generate a multi-level prompt and query a model."""
+        rng = random.Random(seed) if seed is not None else random
         if primary_path is None:
             primary_path = [
-                random.randint(0, self.root_matrix.size - 1)
+                rng.randint(0, self.root_matrix.size - 1)
                 for _ in range(self.root_matrix.size)
             ]
 
         prompt = self.generate_multi_level_prompt(
-            primary_path, sub_paths, include_metacommentary
+            primary_path, sub_paths, include_metacommentary, seed=seed
         )
 
         try:

--- a/tests/test_ekm.py
+++ b/tests/test_ekm.py
@@ -34,3 +34,31 @@ def test_generate_micro_prompt_with_metacommentary():
     path = [0, 1]
     prompt = ekm.generate_micro_prompt(path, include_metacommentary=True)
     assert "After completing this task" in prompt
+
+
+def test_traverse_deterministic_with_seed():
+    ekm = create_random_ekm(3)
+
+    def dummy_model(prompt: str) -> str:
+        return "ok"
+
+    result1 = ekm.traverse(dummy_model, include_metacommentary=False, seed=123)
+    result2 = ekm.traverse(dummy_model, include_metacommentary=False, seed=123)
+
+    assert result1["path"] == result2["path"]
+    assert result1["prompt"] == result2["prompt"]
+
+
+def test_multi_traverse_deterministic_with_seed():
+    ekm = create_random_ekm(3)
+
+    def dummy_model(prompt: str) -> str:
+        return "ok"
+
+    runs1 = ekm.multi_traverse(dummy_model, num_paths=3, include_metacommentary=False, seed=42)
+    runs2 = ekm.multi_traverse(dummy_model, num_paths=3, include_metacommentary=False, seed=42)
+
+    paths1 = [r["path"] for r in runs1]
+    paths2 = [r["path"] for r in runs2]
+
+    assert paths1 == paths2


### PR DESCRIPTION
## Summary
- extend `EigenKoanMatrix.traverse` with optional `seed`
- add seed support for `multi_traverse`
- pass seed through recursive EKM traversal helpers
- test deterministic behavior when seed is set

## Testing
- `python -m tests.pytest -q`