### PR TITLE
Add downloader test and document dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ source ekm-env/bin/activate  # On Windows: ekm-env\Scripts\activate
 pip install -r requirements.txt
 ```
 
+### Dependencies
+The project relies on the following external Python packages:
+
+- `matplotlib`
+- `seaborn`
+- `nltk`
+- `wordcloud`
+- `textblob`
+- `torch`
+- `transformers`
+- `openai`
+
+No specific version pins are required; the latest stable releases of these
+libraries should work.
+```
+
 ## Quick Start
 
 ```python

--- a/downloader.py
+++ b/downloader.py
@@ -1,0 +1,7 @@
+class Downloader:
+    """Simple data downloader that reads from a file path."""
+    def download(self, path: str) -> bytes:
+        """Return the bytes from the given file path."""
+        with open(path, 'rb') as f:
+            return f.read()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+matplotlib
+seaborn
+nltk
+wordcloud
+textblob
+torch
+transformers
+openai

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,0 +1,19 @@
+from tests import pytest
+import os
+import tempfile
+from downloader import Downloader
+
+
+def test_download_behavior():
+    # Create a temporary file with more than 50 bytes
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        tmp.write(b"x" * 60)
+        tmp_path = tmp.name
+
+    try:
+        downloader = Downloader()
+        data = downloader.download(tmp_path)
+        assert isinstance(data, (bytes, bytearray))
+        assert len(data) >= 50
+    finally:
+        os.remove(tmp_path)


### PR DESCRIPTION
## Summary
- provide a simple Downloader utility
- test Downloader with a new pytest-based test
- list external dependencies in README
- add requirements.txt for installation

## Testing
- `PYTHONPATH=. python tests/pytest.py -q`