### PR TITLE
Add generator and analyzer tests

### DIFF
--- a/tests/test_ekm_analyzer.py
+++ b/tests/test_ekm_analyzer.py
@@ -1,0 +1,105 @@
+from tests import pytest
+import os, json, shutil, sys, types
+
+def setup_modules():
+    plt = types.ModuleType('matplotlib.pyplot')
+    plt.figure = lambda *a, **k: None
+    plt.subplots = lambda *a, **k: ((types.SimpleNamespace(), types.SimpleNamespace()), None)
+    plt.close = lambda *a, **k: None
+    plt.savefig = lambda *a, **k: None
+    sys.modules['matplotlib'] = types.ModuleType('matplotlib')
+    sys.modules['matplotlib.pyplot'] = plt
+    sys.modules['seaborn'] = types.ModuleType('seaborn')
+    wc = types.ModuleType('wordcloud')
+    wc.WordCloud = lambda **k: types.SimpleNamespace(generate_from_frequencies=lambda f: None)
+    sys.modules['wordcloud'] = wc
+
+    sk = types.ModuleType('sklearn')
+    fe = types.ModuleType('sklearn.feature_extraction')
+    fe_text = types.ModuleType('sklearn.feature_extraction.text')
+    class TF:
+        def __init__(self, *a, **k):
+            pass
+        def fit_transform(self, X):
+            class Mat(list):
+                def tolist(self):
+                    return self
+            return Mat([[1 for _ in X] for _ in X])
+    fe_text.TfidfVectorizer = TF
+    fe.text = fe_text
+    metrics = types.ModuleType('sklearn.metrics')
+    class SimMat(list):
+        def tolist(self):
+            return self
+    pair = types.ModuleType('sklearn.metrics.pairwise')
+    pair.cosine_similarity = lambda X: SimMat([[1 for _ in X] for _ in X])
+    metrics.pairwise = pair
+    sk.feature_extraction = fe
+    sk.metrics = metrics
+    sk.decomposition = types.ModuleType('sklearn.decomposition')
+    sk.decomposition.PCA = lambda *a, **k: None
+    sk.manifold = types.ModuleType('sklearn.manifold')
+    sk.manifold.TSNE = lambda *a, **k: None
+    sys.modules['sklearn'] = sk
+    sys.modules['sklearn.feature_extraction'] = fe
+    sys.modules['sklearn.feature_extraction.text'] = fe_text
+    sys.modules['sklearn.metrics'] = metrics
+    sys.modules['sklearn.metrics.pairwise'] = pair
+    sys.modules['sklearn.decomposition'] = sk.decomposition
+    sys.modules['sklearn.manifold'] = sk.manifold
+
+    nltk = types.ModuleType('nltk')
+    nltk.download = lambda *a, **k: None
+    class SIA:
+        def polarity_scores(self, text):
+            return {'pos': 0.0, 'neg': 0.0, 'compound': 0.0}
+    nltk.sentiment = types.ModuleType('nltk.sentiment')
+    nltk.sentiment.SentimentIntensityAnalyzer = SIA
+    nltk.corpus = types.ModuleType('nltk.corpus')
+    nltk.corpus.stopwords = types.SimpleNamespace(words=lambda lang: set())
+    nltk.word_tokenize = lambda text: text.split()
+    nltk.sent_tokenize = lambda text: [text]
+    sys.modules['nltk'] = nltk
+    sys.modules['nltk.sentiment'] = nltk.sentiment
+    sys.modules['nltk.corpus'] = nltk.corpus
+
+    textblob = types.ModuleType('textblob')
+    textblob.TextBlob = lambda text: types.SimpleNamespace(sentiment=types.SimpleNamespace(polarity=0.0, subjectivity=0.0))
+    sys.modules['textblob'] = textblob
+
+    import numpy as np
+    if not hasattr(np, 'corrcoef'):
+        class Arr(list):
+            def __getitem__(self, idx):
+                if isinstance(idx, tuple):
+                    r, c = idx
+                    return super().__getitem__(r)[c]
+                return super().__getitem__(idx)
+        np.corrcoef = lambda a, b: Arr([[0, 0], [0, 0]])
+
+
+def test_analyze_single_result_basic():
+    setup_modules()
+    from ekm_analyzer import EKMAnalyzer
+    os.makedirs('mock_results', exist_ok=True)
+    try:
+        with open('mock_results/test.json', 'w') as f:
+            json.dump({
+                'matrix_name': 'M',
+                'model_name': 'model',
+                'results': [{
+                    'response': 'text',
+                    'prompt': 'p',
+                    'path': [0],
+                    'main_diagonal_affect': 'A',
+                    'main_diagonal_strength': 1.0,
+                    'anti_diagonal_affect': 'B',
+                    'anti_diagonal_strength': 0.0
+                }]
+            }, f)
+        analyzer = EKMAnalyzer(results_dir='mock_results')
+        result = analyzer.analyze_single_result(0)
+        assert result['matrix_name'] == 'M'
+        assert result['response_count'] == 1
+    finally:
+        shutil.rmtree('mock_results', ignore_errors=True)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,58 @@
+import sys, types
+
+# ensure minimal sklearn stubs for import
+sk = types.ModuleType('sklearn')
+cluster = types.ModuleType('sklearn.cluster')
+class KMeans:
+    def __init__(self, *a, **k):
+        pass
+    def fit_predict(self, X):
+        return [0] * len(X)
+    @property
+    def cluster_centers_(self):
+        return [[0 for _ in range(len(X[0]))] for X in [X] if X]
+cluster.KMeans = KMeans
+metrics = types.ModuleType('sklearn.metrics')
+pair = types.ModuleType('sklearn.metrics.pairwise')
+pair.cosine_similarity = lambda X, Y=None: [[0 for _ in range(len(X))] for _ in range(len(X))]
+metrics.pairwise = pair
+sk.cluster = cluster
+sk.metrics = metrics
+sys.modules['sklearn'] = sk
+sys.modules['sklearn.cluster'] = cluster
+sys.modules['sklearn.metrics'] = metrics
+sys.modules['sklearn.metrics.pairwise'] = pair
+
+from eigen_koan_matrix import EigenKoanMatrix
+from ekm_generator import EKMGenerator
+
+class DummyGenerator(EKMGenerator):
+    def _select_diverse_elements(self, elements, count, embedding_key=None):
+        return elements[:count]
+
+    def _find_contrastive_pair(self, elements):
+        return elements[0], elements[1]
+
+    def _select_emotion_tokens(self, emotion_name, count, excluded_tokens=None):
+        return [f"{emotion_name}_{i}" for i in range(count)]
+
+def test_generate_ekm_basic():
+    gen = DummyGenerator()
+    ekm = gen.generate_ekm(size=2)
+    assert isinstance(ekm, EigenKoanMatrix)
+    assert ekm.size == 2
+    assert len(ekm.task_rows) == 2
+    assert len(ekm.constraint_cols) == 2
+    for i in range(2):
+        assert ekm.cells[i][i] != "{NULL}"
+        assert ekm.cells[i][1 - i] != "{NULL}"
+    assert ekm.name == "Generated EKM 2x2"
+
+def test_generate_themed_matrices_basic():
+    gen = DummyGenerator()
+    themes = ["ethics", "custom"]
+    mats = gen.generate_themed_matrices(themes, size=2)
+    assert set(mats.keys()) == set(themes)
+    for matrix in mats.values():
+        assert isinstance(matrix, EigenKoanMatrix)
+        assert matrix.size == 2

--- a/tests/test_recursive_ekm.py
+++ b/tests/test_recursive_ekm.py
@@ -20,3 +20,14 @@ def test_recursive_ekm_traverse_basic():
     assert result["matrix_name"] == "Root"
     assert "Sub-matrix" in result["prompt"]
     assert result["response"] == "dummy-response"
+
+def test_recursive_ekm_traverse_fields():
+    root = create_random_ekm(2)
+    rec = RecursiveEKM(root_matrix=root, name="Root2")
+
+    def dummy(prompt: str) -> str:
+        return "ok"
+
+    result = rec.traverse(dummy, primary_path=[0, 1], include_metacommentary=False)
+    assert set(result.keys()) == {"matrix_name", "primary_path", "prompt", "response"}
+    assert result["matrix_name"] == "Root2"


### PR DESCRIPTION
## Summary
- create dummy sklearn stubs and unit tests for `EKMGenerator`
- extend recursive EKM tests to verify returned fields
- mock heavy dependencies to test `EKMAnalyzer.analyze_single_result`

## Testing
- `python -m tests.pytest -q`