### PR TITLE
Add FastAPI web UI for EKM exploration

### DIFF
--- a/ekm_web.py
+++ b/ekm_web.py
@@ -1,0 +1,106 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+import json
+
+from eigen_koan_matrix import create_random_ekm, EigenKoanMatrix
+
+app = FastAPI(title="EKM Explorer")
+
+# In-memory matrix state
+default_size = 4
+matrix: EigenKoanMatrix = create_random_ekm(default_size)
+
+HTML_PAGE = """
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset='utf-8'>
+<title>EKM Explorer</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 20px; }
+#matrix td { border: 1px solid #666; padding: 6px; cursor: pointer; transition: background-color 0.3s; }
+#matrix td.selected { background-color: #e0f7fa; }
+.fade { opacity: 0; transition: opacity 0.5s; }
+</style>
+</head>
+<body>
+<h1>Eigen-Koan Matrix Explorer</h1>
+<button id='random'>Randomize Matrix</button>
+<div id='stats'></div>
+<table id='matrix'></table>
+<script>
+let currentMatrix = null;
+let currentPath = [];
+async function loadMatrix(){
+  const res = await fetch('/api/matrix');
+  currentMatrix = await res.json();
+  const table = document.getElementById('matrix');
+  table.classList.add('fade');
+  table.innerHTML='';
+  for(let r=0;r<currentMatrix.size;r++){
+    const row = document.createElement('tr');
+    for(let c=0;c<currentMatrix.size;c++){
+      const cell=document.createElement('td');
+      cell.textContent=currentMatrix.cells[r][c];
+      cell.dataset.row=r;
+      cell.dataset.col=c;
+      row.appendChild(cell);
+    }
+    table.appendChild(row);
+  }
+  setTimeout(()=>table.classList.remove('fade'),50);
+  currentPath = [];
+  updateStats();
+}
+
+document.getElementById('matrix').addEventListener('click', async (e)=>{
+  if(e.target.tagName !== 'TD') return;
+  const row = parseInt(e.target.dataset.row);
+  const col = parseInt(e.target.dataset.col);
+  if(row !== currentPath.length) return; // enforce row order
+  e.target.classList.add('selected');
+  currentPath.push(col);
+  const res = await fetch('/api/analyze_path', {method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({path:currentPath})});
+  const data = await res.json();
+  updateStats(data);
+});
+
+document.getElementById('random').onclick=async()=>{
+  await fetch('/api/random', {method:'POST'});
+  await loadMatrix();
+};
+
+function updateStats(data){
+  const div = document.getElementById('stats');
+  if(!data){ div.textContent='Select a path...'; return; }
+  div.textContent = `Main diag strength: ${data.main_diagonal_strength.toFixed(2)} | Anti diag strength: ${data.anti_diagonal_strength.toFixed(2)}`;
+}
+
+loadMatrix();
+</script>
+</body>
+</html>
+"""
+
+@app.get('/', response_class=HTMLResponse)
+async def index():
+    return HTML_PAGE
+
+@app.get('/api/matrix')
+async def get_matrix():
+    return JSONResponse(json.loads(matrix.to_json()))
+
+@app.post('/api/random')
+async def random_matrix(request: Request):
+    global matrix
+    matrix = create_random_ekm(default_size)
+    return {'status': 'ok'}
+
+@app.post('/api/analyze_path')
+async def analyze_path(data: dict):
+    path = data.get('path', [])
+    analysis = matrix.analyze_path_paradox(path)
+    return {
+        'main_diagonal_strength': analysis['main_diagonal_strength'],
+        'anti_diagonal_strength': analysis['anti_diagonal_strength'],
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ textblob
 torch
 transformers
 openai
+fastapi
+uvicorn
+httpx

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -169,5 +169,28 @@ def patch_external_libs():
     textblob_mod.TextBlob = lambda text: types.SimpleNamespace(sentiment=types.SimpleNamespace(polarity=0.0, subjectivity=0.0))
     modules['textblob'] = textblob_mod
 
+    # httpx stub
+    httpx_mod = types.ModuleType('httpx')
+    class SimpleClient:
+        def __init__(self, *a, **k):
+            pass
+        def request(self, *a, **k):
+            return types.SimpleNamespace(status_code=200, json=lambda: {})
+        get = post = request
+        def close(self):
+            pass
+    httpx_mod.Client = SimpleClient
+    httpx_mod.AsyncClient = SimpleClient
+    class BaseTransport:
+        pass
+    httpx_mod.BaseTransport = BaseTransport
+    class Request:
+        pass
+    class Response(types.SimpleNamespace):
+        pass
+    httpx_mod.Request = Request
+    httpx_mod.Response = Response
+    modules['httpx'] = httpx_mod
+
     with mock.patch.dict(sys.modules, modules):
         yield

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,22 @@
+import asyncio
+import json
+from tests import patch_external_libs
+
+
+def test_get_matrix_endpoint():
+    with patch_external_libs():
+        from ekm_web import get_matrix
+        resp = asyncio.run(get_matrix())
+        data = json.loads(resp.body.decode())
+        assert 'size' in data
+        assert 'cells' in data
+
+
+def test_analyze_path_endpoint():
+    with patch_external_libs():
+        from ekm_web import get_matrix, analyze_path
+        matrix_data = json.loads(asyncio.run(get_matrix()).body.decode())
+        path = list(range(matrix_data['size']))
+        result = asyncio.run(analyze_path({'path': path}))
+        assert 'main_diagonal_strength' in result
+        assert 'anti_diagonal_strength' in result


### PR DESCRIPTION
## Summary
- build a simple FastAPI app for exploring EKMs via a browser
- support random matrix generation and path strength analysis
- provide tests for new endpoints
- extend test stubs to include `httpx`
- list `fastapi`, `uvicorn`, and `httpx` in requirements

## Testing
- `python -m tests.pytest -q`