### PR TITLE
Add SQLite database integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,14 +201,17 @@ loaded = RecursiveEKM.from_json(json_str)
 
 ```python
 from ekm_stack import EKMExperiment
+from ekm_db import EKMDatabase
 
 # Setup an experiment across multiple models and matrices
+db = EKMDatabase("results.db")
 experiment = EKMExperiment(
     name="constraint_hierarchy_study",
     description="Investigating how different models prioritize constraints",
     matrices={"phil": philosophical, "ethical": ethical_matrix},
     models=["gpt-3.5-turbo", "claude", "llama-2-70b"],
-    paths={"phil": [[0,1,2,3,4], [4,3,2,1,0]], "ethical": [[0,1,2,3,4]]}
+    paths={"phil": [[0,1,2,3,4], [4,3,2,1,0]], "ethical": [[0,1,2,3,4]]},
+    db=db
 )
 
 # Run the experiment

--- a/ekm_db.py
+++ b/ekm_db.py
@@ -1,0 +1,100 @@
+import sqlite3
+import json
+import datetime
+from typing import Any, Dict, List, Optional
+
+class EKMDatabase:
+    """Simple SQLite-backed storage for experiment results."""
+
+    def __init__(self, db_path: str = "ekm_results.db"):
+        self.conn = sqlite3.connect(db_path)
+        self._migrate()
+
+    def _migrate(self):
+        cur = self.conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.execute("CREATE TABLE IF NOT EXISTS schema_version (version INTEGER)")
+        row = cur.execute("SELECT version FROM schema_version").fetchone()
+        version = row[0] if row else 0
+        migrations = [self._migration_1]
+        while version < len(migrations):
+            migrations[version]()
+            version += 1
+            cur.execute("DELETE FROM schema_version")
+            cur.execute("INSERT INTO schema_version (version) VALUES (?)", (version,))
+            self.conn.commit()
+
+    def _migration_1(self):
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE results (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                experiment_name TEXT,
+                matrix_id TEXT,
+                model_name TEXT,
+                path TEXT,
+                data TEXT,
+                created_at TEXT
+            )
+            """
+        )
+        self.conn.commit()
+
+    def add_result(self, experiment_name: str, matrix_id: str, model_name: str, path: List[int], data: Dict[str, Any]):
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO results (experiment_name, matrix_id, model_name, path, data, created_at) VALUES (?,?,?,?,?,?)",
+            (
+                experiment_name,
+                matrix_id,
+                model_name,
+                json.dumps(path),
+                json.dumps(data),
+                datetime.datetime.utcnow().isoformat(),
+            ),
+        )
+        self.conn.commit()
+
+    def query_results(
+        self,
+        experiment_name: Optional[str] = None,
+        matrix_id: Optional[str] = None,
+        model_name: Optional[str] = None,
+        after: Optional[str] = None,
+        before: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        clauses = []
+        params: List[Any] = []
+        if experiment_name:
+            clauses.append("experiment_name=?")
+            params.append(experiment_name)
+        if matrix_id:
+            clauses.append("matrix_id=?")
+            params.append(matrix_id)
+        if model_name:
+            clauses.append("model_name=?")
+            params.append(model_name)
+        if after:
+            clauses.append("created_at>=?")
+            params.append(after)
+        if before:
+            clauses.append("created_at<=?")
+            params.append(before)
+        where = " WHERE " + " AND ".join(clauses) if clauses else ""
+        cur = self.conn.cursor()
+        query = f"SELECT experiment_name, matrix_id, model_name, path, data, created_at FROM results{where}"
+        rows = cur.execute(query, params).fetchall()
+        results = []
+        for r in rows:
+            results.append(
+                {
+                    "experiment_name": r[0],
+                    "matrix_id": r[1],
+                    "model_name": r[2],
+                    "path": json.loads(r[3]),
+                    "data": json.loads(r[4]),
+                    "created_at": r[5],
+                }
+            )
+        return results

--- a/ekm_stack.py
+++ b/ekm_stack.py
@@ -21,6 +21,7 @@ from typing import Dict, List, Any, Optional, Union, Tuple
 from dataclasses import dataclass
 from pathlib import Path
 from rich.console import Console
+from ekm_db import EKMDatabase
 try:
     from rich.progress import (
         Progress,
@@ -60,6 +61,7 @@ class EKMExperiment:
     models: List[str]
     paths: Dict[str, List[List[int]]]  # Maps matrix_id to paths
     results_dir: str = "./ekm_results"
+    db: Optional[EKMDatabase] = None
     
     def __post_init__(self):
         """Setup experiment directory structure."""
@@ -146,6 +148,14 @@ class EKMExperiment:
                         # Generate prompt and get response
                         result = matrix.traverse(model_fn, path=path, include_metacommentary=True)
                         model_results.append(result)
+                        if self.db is not None:
+                            self.db.add_result(
+                                experiment_name=self.name,
+                                matrix_id=matrix_id,
+                                model_name=model_name,
+                                path=path,
+                                data=result,
+                            )
                         
                         # Update progress
                         progress.update(task, advance=1)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,18 @@
+from tests import pytest
+import os
+import tempfile
+
+from ekm_db import EKMDatabase
+
+
+def test_db_insert_and_query():
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        db_path = tmp.name
+    try:
+        db = EKMDatabase(db_path)
+        db.add_result("exp", "m1", "model", [0, 1], {"response": "ok"})
+        results = db.query_results(experiment_name="exp", matrix_id="m1")
+        assert len(results) == 1
+        assert results[0]["data"]["response"] == "ok"
+    finally:
+        os.remove(db_path)


### PR DESCRIPTION
## Summary
- create `EKMDatabase` for storing experiment results in SQLite
- allow `EKMExperiment` to log results to the database
- document database usage in README
- add tests for database operations

## Testing
- `python -m tests.pytest -q`